### PR TITLE
Proposal for cache interface update

### DIFF
--- a/gokey/operations.go
+++ b/gokey/operations.go
@@ -5,11 +5,11 @@ import "time"
 // Operations contains all the basic operations for all the interactions with the data structure (cache).
 type Operations interface {
 	// get returns a value and an optional error given a key.
-	get(key string) (interface{}, error)
+	get(key string) ([]byte, error)
 
 	// upsert is for create/update operation in the cache. If 0 or negative, the entry will not expire.
 	// Returns whether the entry was created with this operation or not (updated) and an optional error
-	upsert(key string, value interface{}, ttl time.Duration) (bool, error)
+	upsert(key string, value []byte, ttl time.Duration) (bool, error)
 
 	// delete removes a value given a key.
 	// Returns whether the entry was deleted or not and an optional error

--- a/gokey/operations.go
+++ b/gokey/operations.go
@@ -1,12 +1,17 @@
 package gokey
 
+import "time"
+
 // Operations contains all the basic operations for all the interactions with the data structure (cache).
 type Operations interface {
-	// get a value given a key.
-	get(key string) (string, error)
-	// upsert is for create/update operation in the cache. ttl should be expressed in millis.
-	// If 0, the entry will not expire.
-	upsert(key, value string, ttl int) (bool, error)
-	//delete a value given a key
+	// get returns a value and an optional error given a key.
+	get(key string) (interface{}, error)
+
+	// upsert is for create/update operation in the cache. If 0 or negative, the entry will not expire.
+	// Returns whether the entry was created with this operation or not (updated) and an optional error
+	upsert(key string, value interface{}, ttl time.Duration) (bool, error)
+
+	// delete removes a value given a key.
+	// Returns whether the entry was deleted or not and an optional error
 	delete(key string) (bool, error)
 }


### PR DESCRIPTION
Actualizo comentarios y propongo cambios en la interfaz base de cache:

1. Desacoplo los tipos de objeto valor a `interface{}`. `string` es un tipo muy restrictivo para representaciones de valores a cachear, aunque si buscamos un punto medio podemos utilizar tambien `[]byte`, que es convertible a `string` sin overhead y es el el tipo utilizado por las interfases Marshaler/Unmarshaler
2. Cambio el tipo de TTL por `time.Duration`. Esto es mas idiomático por parte del lenguaje (los consumidores van a poder configurar valores de forma mas ergonómica) y es probablemente el tipo compatible con las APIs e implementaciones que utilicemos para los mecanismos de espera y evicción internos