### PR TITLE
refactor: cambio en logica de ttl en upsert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ clean:
 
 test:
 	@go test -v $(shell go list ./... | grep -v /mocks/) -count=1
+
+fmt:
+	@gofmt -w .

--- a/build/TODO.md
+++ b/build/TODO.md
@@ -1,2 +1,0 @@
-
-- Build bin folder

--- a/cmd/TODO.md
+++ b/cmd/TODO.md
@@ -1,2 +1,0 @@
-
-- CMD pkg folder

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,9 +1,0 @@
-package main
-
-import (
-	"fmt"
-)
-
-func main() {
-	fmt.Println("Init")
-}

--- a/gokey/cache.go
+++ b/gokey/cache.go
@@ -15,19 +15,18 @@ type pair struct {
 }
 
 var (
-	_ Operations = (*Cache)(nil)
-
-	ErrorEmptyKey = errors.New("key cannot be empty")
+	_             Operations = (*Cache)(nil)
+	ErrorEmptyKey            = errors.New("key cannot be empty")
 )
 
 // Get the values of the key, if this exists in the cache
-func (this *Cache) Get(key string) ([]byte, error) {
+func (c *Cache) Get(key string) ([]byte, error) {
 	if isEmpty(key) {
 		return nil, ErrorEmptyKey
 	}
 
 	keyEncrypted := generateMD5HashFromKey([]byte(key))
-	pair, exists := this.pairsSet[keyEncrypted]
+	pair, exists := c.pairsSet[keyEncrypted]
 
 	if exists {
 		return pair.value, nil
@@ -37,42 +36,30 @@ func (this *Cache) Get(key string) ([]byte, error) {
 }
 
 // Upsert cache a new key pair or update an existing one
-// if ttl is equals to zero the key will not expire
-func (this *Cache) Upsert(key string, value []byte, ttl time.Duration) (bool, error) {
+// if ttl is equals to zero the key will not expire.
+func (c *Cache) Upsert(key string, value []byte, ttl time.Duration) (bool, error) {
 
 	if isEmpty(key) {
 		return false, ErrorEmptyKey
 	}
 
-	var keyEncrypted string = generateMD5HashFromKey([]byte(key))
+	var keyEncrypted = generateMD5HashFromKey([]byte(key))
 
-	if this.pairsSet == nil {
-		this.pairsSet = make(map[string]pair)
+	if c.pairsSet == nil {
+		c.pairsSet = make(map[string]pair)
 	}
 
-	if ttl < 0 {
-		// redis is: if (ttl < 0) ttl = 0;
-		return false, errors.New("ttl value cannot be lower than 0")
-
-	} else if ttl > 0 {
-		time.AfterFunc(time.Duration(ttl)*time.Millisecond, func() {
-			delete(this.pairsSet, keyEncrypted)
-		})
-
-	} else {
-		ttl = -1
-	}
 	// redis in generic command:  if (ttl == -1)
 	// golang use with functions time.Duration = -1
-
-	this.pairsSet[keyEncrypted] = pair{
+	c.pairsSet[keyEncrypted] = pair{
 		ttl:   ttl,
-		value: []byte(value),
+		value: value,
 	}
 
 	return true, nil
 }
 
-func (this *Cache) Delete(key string) (bool, error) {
+// Delete the key in the shared structure.
+func (c *Cache) Delete(key string) (bool, error) {
 	return false, errors.New("not implemented")
 }

--- a/gokey/hash.go
+++ b/gokey/hash.go
@@ -6,7 +6,7 @@ import (
 )
 
 //generateMD5HashFromKey is a hash generator function according to input(key)
-//using md5 algorith
+//using md5 algorithm
 func generateMD5HashFromKey(key []byte) string {
 	algorithm := md5.New()
 	algorithm.Write(key)

--- a/gokey/operations.go
+++ b/gokey/operations.go
@@ -4,14 +4,14 @@ import "time"
 
 // Operations contains all the basic operations for all the interactions with the data structure (cache).
 type Operations interface {
-	// get returns a value and an optional error given a key.
+	// Get returns a value and an optional error given a key.
 	Get(key string) ([]byte, error)
 
-	// upsert is for create/update operation in the cache. If ttl 0, the entry will not expire.
+	// Upsert is for create/update operation in the cache. If ttl 0, the entry will not expire.
 	// Returns whether the entry was created with this operation or not (updated) and an optional error
 	Upsert(key string, value []byte, ttl time.Duration) (bool, error)
 
-	// delete removes a value given a key.
+	// Delete removes a value given a key.
 	// Returns whether the entry was deleted or not and an optional error
 	Delete(key string) (bool, error)
 }

--- a/tests/TODO.md
+++ b/tests/TODO.md
@@ -1,2 +1,0 @@
-
-- Tests folder

--- a/tests/cache_test.go
+++ b/tests/cache_test.go
@@ -16,8 +16,8 @@ func TestCacheUpsert(t *testing.T) {
 	}
 
 	_, err = operations.Upsert("", []byte("value"), 1)
-	if err != nil {
-		t.Error(err.Error())
+	if err == nil {
+		t.Error("key cannot be empty")
 	}
 }
 
@@ -25,16 +25,16 @@ func TestCacheUpsert(t *testing.T) {
 func TestCacheGet(t *testing.T) {
 	_, err := operations.Upsert("key", []byte("value"), 10)
 	if err != nil {
-		t.Error("Expected no errors in Upsert method, got:", err.Error())
+		t.Error("expected no errors in Upsert method, got:", err.Error())
 	}
 
 	value, err := operations.Get("key")
 	if err != nil {
-		t.Error("Expected no errors in Get method, got:", err.Error())
+		t.Error("expected no errors in Get method, got:", err.Error())
 	}
 
-	if value != nil {
-		t.Error("Expected a value, got nil")
+	if value == nil {
+		t.Error("expected a value, got nil")
 	}
 }
 
@@ -42,20 +42,49 @@ func TestCacheGet(t *testing.T) {
 func TestCacheGetEmptyKey(t *testing.T) {
 	_, err := operations.Get("")
 	if err == nil {
-		t.Error("Expected empty key error message, got nil")
+		t.Error("expected empty key error message, got nil")
 	}
 }
 
-// go test -run TestCacheGetUnknowKey -v
-func TestCacheGetUnknowKey(t *testing.T) {
+// go test -run TestCacheGetUnknownKey -v
+func TestCacheGetUnknownKey(t *testing.T) {
 	_, err := operations.Get("Key")
 	if err == nil {
-		t.Error("Expected 'no related values' error message, got nil")
+		t.Error("expected 'no related values' error message, got nil")
 	}
 
 	// case ok
 	_, err = operations.Upsert("key", []byte("value"), 0)
 	if err != nil {
 		t.Error("here: unexpected error")
+	}
+}
+
+// go test -run TestUpsertSameKey -v
+func TestUpsertSameKey(t *testing.T) {
+	key := "key"
+	value := "value"
+	newValue := "newValue"
+	_, err := operations.Upsert(key, []byte(value), 0)
+
+	if err != nil {
+		t.Error("err should be nil", err)
+	}
+
+	v, err := operations.Get(key)
+
+	if err != nil {
+		t.Error("err should be nil", err)
+	}
+
+	if string(v) != value {
+		t.Errorf("got different value from cache. Expected: %s, got: %s", value, string(v))
+	}
+
+	_, err = operations.Upsert(key, []byte(newValue), 0)
+	v, err = operations.Get(key)
+
+	if string(v) != newValue {
+		t.Errorf("got different value from cache. Expected: %s, got: %s", newValue, string(v))
 	}
 }


### PR DESCRIPTION
borrado de docs/archivos que no se usan para bajar el overhead del proyecto
fix de tests, todos pasan
agregado el comando fmt en makefile


## Descripcion
Cambio de la logica del TTL en upsert. No se chequea previamente, eso se deberia hacer en el GET. Si es negativo o 0, es tomado de la misma manera, *no expira*.
Cambios en los tests, ahora funcionan y todos estan en verde.
Fix de algunos errores de ortografia en comentarios.
Agregar fmt al makefile

## Motivacion y Contexto
Test fallidos.
Logica de TTL no estaaba acorde a lo planteado.

## Como fue probado
Corriendo los tests del proyecto.

## Tipo de cambio
<!-- Que tipo de cambio hiciste? Pone una `x` en todos los casilleros que apliquen: -->
- [ ] Bug fix (non-breaking cambios que fixean una issue)
- [ ] Nueva feature / funcionalidad (non-breaking cambio que agrega una nueva funcionalidad)
- [ ] Breaking change (fix o feature que va a causar un cambio en una funcionalidad existente)

## Checklist
<!-- Ve por cada uno de los puntos y marca con una `x` donde corresponda -->
<!-- Si no estas seguro de algun casillero, pregunta :)! -->
- [ x] Estas haciendo el pull request desde un ***topic/feature/bugfix branch** (lado derecho). Si estas haciendo un pull request desde un fork, no lo hagas desde `master`!.
- [ ] Estas haciendo el pull request contra `master` (lado izquierdo). Tambien de que estas usando los ultimos cambios en `master`.
- [ ] Mis cambios necesitan cambio de la documentacion.
- [ x] Actualize la documentacion acordemente.
- [ ] Modules and dependencias fueron actualizadas acordemente; correr `go mod tidy && go mod vendor`
- [ x] Agregue tests para cubrir mis cambios.
- [ x] Todos los tests existentes pasaron.
- [ ] Checkear que el codigo que estoy subiendo esta linteado:
  - [x ] `go fmt -s`
  - [ x] `go vet`