### PR TITLE
add expired assertion in Get function, refactor Upsert and fix tests

### DIFF
--- a/gokey/cache.go
+++ b/gokey/cache.go
@@ -19,7 +19,6 @@ var (
 	_ Operations = (*Cache)(nil)
 
 	ErrEmptyKey       = errors.New("key cannot be empty")
-	ErrExpiredKey     = errors.New("key expired")
 	ErrNoExistKey     = errors.New("key does not exist")
 	ErrNotImplemented = errors.New("not implemented")
 )
@@ -38,7 +37,7 @@ func (c *Cache) Get(key string) ([]byte, error) {
 
 	if time.Since(pair.createdAt) > pair.ttl && pair.ttl != -1 {
 		delete(c.pairsSet, keyEncrypted)
-		return nil, ErrExpiredKey
+		return nil, ErrNoExistKey
 	}
 
 	return pair.value, nil

--- a/gokey/cache.go
+++ b/gokey/cache.go
@@ -36,7 +36,7 @@ func (c *Cache) Get(key string) ([]byte, error) {
 		return nil, ErrNoExistKey
 	}
 
-	if time.Since(pair.createdAt) > pair.ttl {
+	if time.Since(pair.createdAt) > pair.ttl && pair.ttl != -1 {
 		delete(c.pairsSet, keyEncrypted)
 		return nil, ErrExpiredKey
 	}
@@ -52,7 +52,7 @@ func (c *Cache) Upsert(key string, value []byte, ttl time.Duration) (bool, error
 		return false, ErrEmptyKey
 	}
 
-	var keyEncrypted string = generateMD5HashFromKey([]byte(key))
+	var keyEncrypted = generateMD5HashFromKey([]byte(key))
 
 	if c.pairsSet == nil {
 		c.pairsSet = make(map[string]pair)

--- a/gokey/hash.go
+++ b/gokey/hash.go
@@ -6,7 +6,7 @@ import (
 )
 
 //generateMD5HashFromKey is a hash generator function according to input(key)
-//using md5 algorith
+//using md5 algorithm
 func generateMD5HashFromKey(key []byte) string {
 	algorithm := md5.New()
 	algorithm.Write(key)

--- a/gokey/operations.go
+++ b/gokey/operations.go
@@ -4,14 +4,14 @@ import "time"
 
 // Operations contains all the basic operations for all the interactions with the data structure (cache).
 type Operations interface {
-	// get returns a value and an optional error given a key.
+	// Get returns a value and an optional error given a key.
 	Get(key string) ([]byte, error)
 
-	// upsert is for create/update operation in the cache. If ttl 0, the entry will not expire.
+	// Upsert is for create/update operation in the cache. If ttl 0, the entry will not expire.
 	// Returns whether the entry was created with this operation or not (updated) and an optional error
 	Upsert(key string, value []byte, ttl time.Duration) (bool, error)
 
-	// delete removes a value given a key.
+	// Delete removes a value given a key.
 	// Returns whether the entry was deleted or not and an optional error
 	Delete(key string) (bool, error)
 }

--- a/tests/cache_test.go
+++ b/tests/cache_test.go
@@ -53,7 +53,7 @@ func TestCacheGetExpiredKey(t *testing.T) {
 		t.Error("expected ErrExpiredKey, got: nil")
 	}
 	if err != nil {
-		if !errors.Is(err, gokey.ErrExpiredKey) {
+		if !errors.Is(err, gokey.ErrNoExistKey) {
 			t.Error("expected ErrExpiredKey, got:", err.Error())
 		}
 	}

--- a/tests/cache_test.go
+++ b/tests/cache_test.go
@@ -14,7 +14,7 @@ var operations gokey.Operations = new(gokey.Cache)
 func TestCacheUpsert(t *testing.T) {
 	_, err := operations.Upsert("key", []byte("value"), -1)
 	if err != nil {
-		t.Error(err.Error())
+		t.Error("key cannot be empty")
 	}
 
 	_, err = operations.Upsert("", []byte("value"), 1)
@@ -27,16 +27,16 @@ func TestCacheUpsert(t *testing.T) {
 func TestCacheGet(t *testing.T) {
 	_, err := operations.Upsert("key", []byte("value"), 10*time.Second)
 	if err != nil {
-		t.Error("Expected no errors in Upsert method, got:", err.Error())
+		t.Error("expected no errors in Upsert method, got:", err.Error())
 	}
 
 	value, err := operations.Get("key")
 	if err != nil {
-		t.Error("Expected no errors in Get method, got:", err.Error())
+		t.Error("expected no errors in Get method, got:", err.Error())
 	}
 
 	if value == nil {
-		t.Error("Expected a value, got nil")
+		t.Error("expected a value, got nil")
 	}
 }
 
@@ -70,20 +70,49 @@ func TestCacheGetExpiredKey(t *testing.T) {
 func TestCacheGetEmptyKey(t *testing.T) {
 	_, err := operations.Get("")
 	if err == nil {
-		t.Error("Expected empty key error message, got nil")
+		t.Error("expected empty key error message, got nil")
 	}
 }
 
-// go test -run TestCacheGetUnknowKey -v
-func TestCacheGetUnknowKey(t *testing.T) {
+// go test -run TestCacheGetUnknownKey -v
+func TestCacheGetUnknownKey(t *testing.T) {
 	_, err := operations.Get("Key")
 	if err == nil {
-		t.Error("Expected 'no related values' error message, got nil")
+		t.Error("expected 'no related values' error message, got nil")
 	}
 
 	// case ok
 	_, err = operations.Upsert("key", []byte("value"), 0)
 	if err != nil {
 		t.Error("here: unexpected error")
+	}
+}
+
+// go test -run TestUpsertSameKey -v
+func TestUpsertSameKey(t *testing.T) {
+	key := "key"
+	value := "value"
+	newValue := "newValue"
+	_, err := operations.Upsert(key, []byte(value), -1)
+
+	if err != nil {
+		t.Error("err should be nil", err)
+	}
+
+	v, err := operations.Get(key)
+
+	if err != nil {
+		t.Error("err should be nil", err)
+	}
+
+	if string(v) != value {
+		t.Errorf("got different value from cache. Expected: %s, got: %s", value, string(v))
+	}
+
+	_, err = operations.Upsert(key, []byte(newValue), -1)
+	v, err = operations.Get(key)
+
+	if string(v) != newValue {
+		t.Errorf("got different value from cache. Expected: %s, got: %s", newValue, string(v))
 	}
 }

--- a/tests/cache_test.go
+++ b/tests/cache_test.go
@@ -44,17 +44,24 @@ func TestCacheGet(t *testing.T) {
 func TestCacheGetExpiredKey(t *testing.T) {
 	_, err := operations.Upsert("key", []byte("value"), 1*time.Second)
 	if err != nil {
-		t.Error("Expected no errors in Upsert method, got:", err.Error())
+		t.Error("expected no errors in Upsert method, got:", err.Error())
 	}
 	time.Sleep(1 * time.Second)
 
 	_, err = operations.Get("key")
 	if err == nil {
-		t.Error("Expected ErrExpiredKey, got: nil")
+		t.Error("expected ErrExpiredKey, got: nil")
 	}
 	if err != nil {
 		if !errors.Is(err, gokey.ErrExpiredKey) {
-			t.Error("Expected ErrExpiredKey, got:", err.Error())
+			t.Error("expected ErrExpiredKey, got:", err.Error())
+		}
+	}
+
+	_, err = operations.Get("key")
+	if err != nil {
+		if !errors.Is(err, gokey.ErrNoExistKey) {
+			t.Error("expected 'key does not exist' error message, got:", err.Error())
 		}
 	}
 }


### PR DESCRIPTION
## Descripcion
El principal objetivo es lograr realizar un assertion de la expiración de la key antes de devolver la información al usuario.
Por otro lado se encontró algunos posibles refactor al Upsert method y fix sobre distintos tests que no estaban pasando.

## Issue Relacionada
https://github.com/gophers-latam/GoKey/projects/1#card-60712576

## Motivacion y Contexto
Insertar una comprobacion de expiracion antes de efectuar un get

## Como fue probado
`make test` provisto en el proyecto

## Screenshots / capturas de pantalla (si es necesario)

## Tipo de cambio
<!-- Que tipo de cambio hiciste? Pone una `x` en todos los casilleros que apliquen: -->
- [x] Bug fix (non-breaking cambios que fixean una issue)
- [x] Nueva feature / funcionalidad (non-breaking cambio que agrega una nueva funcionalidad)
- [ ] Breaking change (fix o feature que va a causar un cambio en una funcionalidad existente)

## Checklist
<!-- Ve por cada uno de los puntos y marca con una `x` donde corresponda -->
<!-- Si no estas seguro de algun casillero, pregunta :)! -->
- [x] Estas haciendo el pull request desde un ***topic/feature/bugfix branch** (lado derecho). Si estas haciendo un pull request desde un fork, no lo hagas desde `master`!.
- [x] Estas haciendo el pull request contra `master` (lado izquierdo). Tambien de que estas usando los ultimos cambios en `master`.
- [ ] Mis cambios necesitan cambio de la documentacion.
- [ ] Actualize la documentacion acordemente.
- [ ] Modules and dependencias fueron actualizadas acordemente; correr `go mod tidy && go mod vendor`
- [x] Agregue tests para cubrir mis cambios.
- [x] Todos los tests existentes pasaron.
- [ ] Checkear que el codigo que estoy subiendo esta linteado:
  - [x] `go fmt -s`
  - [x] `go vet`