### PR TITLE
Feat concurrencia cache

### DIFF
--- a/gokey/cache_test.go
+++ b/gokey/cache_test.go
@@ -2,6 +2,7 @@ package gokey
 
 import (
 	"testing"
+	"time"
 )
 
 var operations Operations = &Cache{pairsSet: map[string]pair{}}
@@ -21,7 +22,7 @@ func TestCacheUpsert(t *testing.T) {
 
 // go test -run TestCacheGet -v
 func TestCacheGet(t *testing.T) {
-	_, err := operations.Upsert("key", []byte("value"), 10)
+	_, err := operations.Upsert("key", []byte("value"), 10*time.Second)
 	if err != nil {
 		t.Error("expected no errors in Upsert method, got:", err.Error())
 	}
@@ -63,7 +64,7 @@ func TestUpsertSameKey(t *testing.T) {
 	key := "key"
 	value := "value"
 	newValue := "newValue"
-	_, err := operations.Upsert(key, []byte(value), 0)
+	_, err := operations.Upsert(key, []byte(value), -1)
 
 	if err != nil {
 		t.Error("err should be nil", err)
@@ -79,7 +80,7 @@ func TestUpsertSameKey(t *testing.T) {
 		t.Errorf("got different value from cache. Expected: %s, got: %s", value, string(v))
 	}
 
-	_, err = operations.Upsert(key, []byte(newValue), 0)
+	_, err = operations.Upsert(key, []byte(newValue), -1)
 	v, err = operations.Get(key)
 
 	if string(v) != newValue {

--- a/tests/cache_test.go
+++ b/tests/cache_test.go
@@ -71,7 +71,7 @@ func TestCacheGetExpiredKey(t *testing.T) {
 	if err != nil {
 		t.Error("expected no errors in Upsert method, got:", err.Error())
 	}
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(101 * time.Millisecond)
 
 	_, err = operations.Get("key")
 	if err == nil {

--- a/tests/cache_test.go
+++ b/tests/cache_test.go
@@ -71,7 +71,7 @@ func TestCacheGetExpiredKey(t *testing.T) {
 	if err != nil {
 		t.Error("expected no errors in Upsert method, got:", err.Error())
 	}
-	time.Sleep(101 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	_, err = operations.Get("key")
 	if err == nil {

--- a/tests/cache_test.go
+++ b/tests/cache_test.go
@@ -23,6 +23,31 @@ func TestCacheUpsert(t *testing.T) {
 	}
 }
 
+// go test -run TestCacheConcurrentUpsert -v
+func TestCacheConcurrentUpsert(t *testing.T) {
+	go operations.Upsert("key", []byte("value"), -1)
+	go operations.Upsert("key2", []byte("hello world"), -1)
+
+	time.Sleep(1000)
+
+	value, err := operations.Get("key")
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	value2, err2 := operations.Get("key2")
+	if err2 != nil {
+		t.Error(err.Error())
+	}
+
+	res := string(value)
+	res2 := string(value2)
+
+	if res != "value" || res2 != "hello world" {
+		t.Error("error while concurrently accessing in the cache")
+	}
+}
+
 // go test -run TestCacheGet -v
 func TestCacheGet(t *testing.T) {
 	_, err := operations.Upsert("key", []byte("value"), 10*time.Second)


### PR DESCRIPTION
## Descripcion
Se agregaron los unit tests para el acceso concurrente a cada una de las functions de la cache

## Issue Relacionada
https://github.com/gophers-latam/GoKey/projects/1#card-61670981

## Motivacion y Contexto
El cambio es requerido porque faltaban probar que realmente funcione el control de concurrencia para el acceso a la cache

## Como fue probado
Fue probado mediante unit tests. Se probo el acceso concurrente a cada una de las operaciones disponibles de la cache mediante el uso de goroutines

## Screenshots / capturas de pantalla (si es necesario)

## Tipo de cambio
<!-- Que tipo de cambio hiciste? Pone una `x` en todos los casilleros que apliquen: -->
- [ ] Bug fix (non-breaking cambios que fixean una issue)
- [x] Nueva feature / funcionalidad (non-breaking cambio que agrega una nueva funcionalidad)
- [ ] Breaking change (fix o feature que va a causar un cambio en una funcionalidad existente)

## Checklist
<!-- Ve por cada uno de los puntos y marca con una `x` donde corresponda -->
<!-- Si no estas seguro de algun casillero, pregunta :)! -->
- [ ] Estas haciendo el pull request desde un ***topic/feature/bugfix branch** (lado derecho). Si estas haciendo un pull request desde un fork, no lo hagas desde `master`!.
- [x] Estas haciendo el pull request contra `master` (lado izquierdo). Tambien de que estas usando los ultimos cambios en `master`.
- [ ] Mis cambios necesitan cambio de la documentacion.
- [ ] Actualize la documentacion acordemente.
- [ ] Modules and dependencias fueron actualizadas acordemente; correr `go mod tidy && go mod vendor`
- [x] Agregue tests para cubrir mis cambios.
- [x] Todos los tests existentes pasaron.
- [ ] Checkear que el codigo que estoy subiendo esta linteado:
  - [x] `go fmt -s`
  - [x] `go vet`